### PR TITLE
Move order review before checkout on mobile

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,178 +44,197 @@ When you install Dintero Checkout, you need to head to the settings page to star
 
 ## Changelog
 
+2021.02.11
+
+* Move order review before checkout on mobile
+
 2021.02.10
-  * Rounding error fix
-  * Css fix for the redirected payment order review
-  * Session lock removed from on session load
-  * Css fix for Cart Mini
-  * Branding image on checkout issue
+
+* Rounding error fix
+* Css fix for the redirected payment order review
+* Session lock removed from on session load
+* Css fix for Cart Mini
+* Branding image on checkout issue
 
 2021.01.15
-  * Firstname,lastname required issue fix
-  * jQuery Fix for document on load
-  * Button Image type added 
+
+* Firstname,lastname required issue fix
+* jQuery Fix for document on load
+* Button Image type added
 
 2020.12.14
 
-  * Shipping address required field issue
-  * Update order meta-data in callback
+* Shipping address required field issue
+* Update order meta-data in callback
 
 2020.12.07
-  * Shipping method and Instance Id Seperation for Callback Order creation
-  * Update in Api request for Few API calls
-  * Included Checkout SDK wihtin the Plugin 
-  * Sanitized few fields for security enhancement
+
+* Shipping method and Instance Id Seperation for Callback Order creation
+* Update in Api request for Few API calls
+* Included Checkout SDK wihtin the Plugin
+* Sanitized few fields for security enhancement
 
 2020.11.27
-  * User agent added , WooCommerce version, Plugin Version
+
+* User agent added , WooCommerce version, Plugin Version
 
 2020.11.25
-  * Shipping name fix Improvement
+
+* Shipping name fix Improvement
 
 2020.11.25
-  * Instance id for shipping method, for callback order creation 
-  * Shipping name fix
-  
+
+* Instance id for shipping method, for callback order creation
+* Shipping name fix
+
 2020.11.23
-   * warning removed from thankyou page
-   * removed reward options from backend setting
-   * add control to add/remove branding image in/from footer
+
+* warning removed from thankyou page
+* removed reward options from backend setting
+* add control to add/remove branding image in/from footer
 
 2020.11.03
-   * 'before_checkout_form_express' warning message fix
-   * probable redirect issue resolve
-   * 'dintero_cart_session' warning resolved 
-   * expire time loop fixed
+
+* 'before_checkout_form_express' warning message fix
+* probable redirect issue resolve
+* 'dintero_cart_session' warning resolved
+* expire time loop fixed
+
 2020.10.30
-  * checkout session validation and some Style fix
+* checkout session validation and some Style fix
+
 2020.10.19
-  * Wrong discount with Coupon code issue in Callback order creation solved
+* Wrong discount with Coupon code issue in Callback order creation solved
+
 2020.10.06
-  * Session Update only with Shipping Options
-  * Improvement in Session lock
+
+* Session Update only with Shipping Options
+* Improvement in Session lock
 
 2020-09-21
 
-* added support for on_hold status 
+* added support for on_hold status
 * added support for dynamic shipping pricing
 * pause, update and resume sessions
 * callback delayed to 3 minutes to prevent duplicate orders
 
 2020-06-05
 
- * Bugfixes
+* Bugfixes
 
 2020-06-02
 
- * supports now embedded/iframe
- * New feature: Express where the Checkout will handle the name, address and shipping
+* supports now embedded/iframe
+* New feature: Express where the Checkout will handle the name, address and shipping
 
 2020-04-04
 
- * updated order shipping address to display information for business customer
- * updated the order payment method, show actual payment method (via Dintero)
-
+* updated order shipping address to display information for business customer
+* updated the order payment method, show actual payment method (via Dintero)
 
 2020-04-02
 
- * updated UI for embed and express mode, display payment as tab
- * updated checkout logo & adjusted setting page to use the one under payment
-
+* updated UI for embed and express mode, display payment as tab
+* updated checkout logo & adjusted setting page to use the one under payment
 
 2020-03-31
 
- * use payment options (list) for not express mode
-
+* use payment options (list) for not express mode
 
 2020-03-26
 
- * removed order review from embed + express mode
-
+* removed order review from embed + express mode
 
 2020-03-19
 
- * fixed express checkout total issue from no shipping country was set and system use different rate than default shipping country
- * removed billing/shipping address from pay form
-
+* fixed express checkout total issue from no shipping country was set and system use different rate than default shipping country
+* removed billing/shipping address from pay form
 
 2020-03-17
 
- * fixed checkout page display glitches for some specific themes
- * added template for checkout and pay form
- * bug fixed and adjustments
-
+* fixed checkout page display glitches for some specific themes
+* added template for checkout and pay form
+* bug fixed and adjustments
 
 2020-03-10
 
- * test on each payment conditions
- * fixed on cancel order and display blank page
- * fixed submit and return blank screen when not check "I have read and agree..." on page My Account > Order > Pay
- * fixed when click cancel from Dintero page, it shows thank you page
-
+* test on each payment conditions
+* fixed on cancel order and display blank page
+* fixed submit and return blank screen when not check "I have read and agree..." on page My Account > Order > Pay
+* fixed when click cancel from Dintero page, it shows thank you page
 
 2020-02-28
 
- * updated for phpcs compatibilities and minor adjustments
+* updated for phpcs compatibilities and minor adjustments
 
 2020-02-27
 
- * commented out calling previous version of plugin
+* commented out calling previous version of plugin
 
 2020-02-26
 
- * adjusted display on embed and not-express settings
+* adjusted display on embed and not-express settings
 
 2020-02-25
 
- * fixed bugs
+* fixed bugs
 
 2020-02-20
 
- * updated and fixed bugs
+* updated and fixed bugs
 
 2020-02-18
 
- * initial updates on woocommerce dintero plugin feature
+* initial updates on woocommerce dintero plugin feature
 
 2020-06-04
- * New Checkout view with improved flow
-    a. Collector issue
-    B. Vat % issue
-    C. Better layout of checkout
+
+* New Checkout view with improved flow
+  a. Collector issue
+  B. Vat % issue
+  C. Better layout of checkout
 
 2020.06.05
- * Cart Item price issue resolved and Express checkout from cart removed billing address fields
+
+* Cart Item price issue resolved and Express checkout from cart removed billing address fields
 
 2020.06.05 - 2
- * Payment cancelled issue resolved, Now it redirects to cart page
+
+* Payment cancelled issue resolved, Now it redirects to cart page
 
 2020.06.08
- * Refund issue resolved
+
+* Refund issue resolved
 
 2020.06.25
- * parameter mismatch warning solved
+
+* parameter mismatch warning solved
+
 2020.07.14
-  * Delayed callback for backup order creation 
+
+* Delayed callback for backup order creation
+
 2020.08.14
-  * Rounding Off of price issue resolved 
+
+* Rounding Off of price issue resolved
 
 2020.09.21
-  * Pause, Update, Resume Session implemented
-  * Supports Dynamic Shipping 
-  * Discount codes in Callback Issue resolved
-  * On_Hold status for collector payment
-  * Failed status for Collector Payment
-  * Callback delay to 3 minutes to prevent duplicate orders
 
+* Pause, Update, Resume Session implemented
+* Supports Dynamic Shipping
+* Discount codes in Callback Issue resolved
+* On_Hold status for collector payment
+* Failed status for Collector Payment
+* Callback delay to 3 minutes to prevent duplicate orders
 
 2020.09.22
-  * Destroy Session 
-  * create new checkout session if current session is COMPLETED, DECLINED, CANCELLED
-  * Business Checkout fix with Update session
-  
-2020.10.06
-  * Session Update only with Shipping Options
-  * Improvement in Session lock
-  
 
+* Destroy Session
+* create new checkout session if current session is COMPLETED, DECLINED, CANCELLED
+* Business Checkout fix with Update session
+
+2020.10.06
+
+* Session Update only with Shipping Options
+* Improvement in Session lock
+  

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ When you install Dintero Checkout, you need to head to the settings page to star
 
 ## Changelog
 
-2021.02.11
+2021.02.12
 
 * Move order review before checkout on mobile
 

--- a/README.txt
+++ b/README.txt
@@ -43,7 +43,7 @@ When you install Dintero Checkout, you need to head to the settings page to star
 
 == Changelog ==
 
-2021.02.11
+2021.02.12
 
   * Move order review before checkout on mobile
 

--- a/README.txt
+++ b/README.txt
@@ -43,7 +43,12 @@ When you install Dintero Checkout, you need to head to the settings page to star
 
 == Changelog ==
 
+2021.02.11
+
+  * Move order review before checkout on mobile
+
 2021.02.10
+
   * Rounding error fix
   * Css fix for the redirected payment order review
   * Session lock removed from on session load
@@ -51,6 +56,7 @@ When you install Dintero Checkout, you need to head to the settings page to star
   * Branding image on checkout issue
 
 2021.01.15
+
   * Firstname,lastname required issue fix
   * jQuery Fix for document on load
   * Button Image type added 
@@ -61,36 +67,46 @@ When you install Dintero Checkout, you need to head to the settings page to star
   * Update order meta-data in callback
 
 2020.12.07
+
   * Shipping method and Instance Id Seperation for Callback Order creation
   * Update in Api request for Few API calls
   * Included Checkout SDK wihtin the Plugin 
   * Sanitized few fields for security enhancement
 
 2020.11.27
+
   * User agent added , WooCommerce version, Plugin Version
 
 2020.11.25
+
   * Shipping name fix Improvement
 
 2020.11.25
+
   * Instance id for shipping method, for callback order creation 
   * Shipping name fix
   
 2020.11.23
+
    * warning removed from thankyou page
    * removed reward options from backend setting
    * add control to add/remove branding image in/from footer
 
 2020.11.03
+
    * 'before_checkout_form_express' warning message fix
    * probable redirect issue resolve
    * 'dintero_cart_session' warning resolved 
    * expire time loop fixed
+
 2020.10.30
   * checkout session validation and some Style fix
+
 2020.10.19
   * Wrong discount with Coupon code issue in Callback order creation solved
+
 2020.10.06
+
   * Session Update only with Shipping Options
   * Improvement in Session lock
 
@@ -115,28 +131,23 @@ When you install Dintero Checkout, you need to head to the settings page to star
  * updated order shipping address to display information for business customer
  * updated the order payment method, show actual payment method (via Dintero)
 
-
 2020-04-02
 
  * updated UI for embed and express mode, display payment as tab
  * updated checkout logo & adjusted setting page to use the one under payment
 
-
 2020-03-31
 
  * use payment options (list) for not express mode
-
 
 2020-03-26
 
  * removed order review from embed + express mode
 
-
 2020-03-19
 
  * fixed express checkout total issue from no shipping country was set and system use different rate than default shipping country
  * removed billing/shipping address from pay form
-
 
 2020-03-17
 
@@ -144,14 +155,12 @@ When you install Dintero Checkout, you need to head to the settings page to star
  * added template for checkout and pay form
  * bug fixed and adjustments
 
-
 2020-03-10
 
  * test on each payment conditions
  * fixed on cancel order and display blank page
  * fixed submit and return blank screen when not check "I have read and agree..." on page My Account > Order > Pay
  * fixed when click cancel from Dintero page, it shows thank you page
-
 
 2020-02-28
 
@@ -178,28 +187,38 @@ When you install Dintero Checkout, you need to head to the settings page to star
  * initial updates on woocommerce dintero plugin feature
 
 2020-06-04
+
  * New Checkout view with improved flow
     a. Collector issue
     B. Vat % issue
     C. Better layout of checkout
 
 2020.06.05
+
  * Cart Item price issue resolved and Express checkout from cart removed billing address fields
 
 2020.06.05 - 2
+
  * Payment cancelled issue resolved, Now it redirects to cart page
 
 2020.06.08
+
  * Refund issue resolved
 
 2020.06.25
+
  * parameter mismatch warning solved
+
 2020.07.14
-  * Delayed callback for backup order creation 
+
+  * Delayed callback for backup order creation
+
 2020.08.14
+
   * Rounding Off of price issue resolved 
 
 2020.09.21
+
   * Pause, Update, Resume Session implemented
   * Supports Dynamic Shipping 
   * Discount codes in Callback Issue resolved
@@ -207,14 +226,13 @@ When you install Dintero Checkout, you need to head to the settings page to star
   * Failed status for Collector Payment
   * Callback delay to 3 minutes to prevent duplicate orders
 
-
 2020.09.22
+
   * Destroy Session 
   * create new checkout session if current session is COMPLETED, DECLINED, CANCELLED
   * Business Checkout fix with Update session
   
 2020.10.06
+
   * Session Update only with Shipping Options
   * Improvement in Session lock
-  
-

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -274,6 +274,7 @@ form.checkout.woocommerce-checkout.dhp-exp {}
       width: 100%;
   }
 
+  .dhp-exp div#order_review.woocommerce-checkout-review-order,
   div#order_review.woocommerce-checkout-review-order {
       width: 100%;
   }

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,5 @@
 *** WooCommerce Dintero Plugin Changelog ***
-2021.02.11
+2021.02.12
   * Move order review before checkout on mobile
 
 2021.02.10

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,7 @@
 *** WooCommerce Dintero Plugin Changelog ***
+2021.02.11
+  * Move order review before checkout on mobile
+
 2021.02.10
   * Rounding error fix
   * Css fix for the redirected payment order review

--- a/dintero-hp.php
+++ b/dintero-hp.php
@@ -3,7 +3,7 @@
 Plugin Name: Dintero Checkout
 Description: Dintero Checkout - Express Checkout
 
-Version:     2021.02.10
+Version:     2021.02.11
 
 Author:      Dintero
 Author URI:  mailto:integration@dintero.com
@@ -15,7 +15,7 @@ Domain Path: /languages
 
 defined( 'ABSPATH' ) || exit;
 
-define( 'DINTERO_HP_VERSION', '2021.02.10' );
+define( 'DINTERO_HP_VERSION', '2021.02.11' );
 
 
 if ( ! defined( 'DHP_PLUGIN_FILE' ) ) {

--- a/dintero-hp.php
+++ b/dintero-hp.php
@@ -3,7 +3,7 @@
 Plugin Name: Dintero Checkout
 Description: Dintero Checkout - Express Checkout
 
-Version:     2021.02.11
+Version:     2021.02.12
 
 Author:      Dintero
 Author URI:  mailto:integration@dintero.com
@@ -15,7 +15,7 @@ Domain Path: /languages
 
 defined( 'ABSPATH' ) || exit;
 
-define( 'DINTERO_HP_VERSION', '2021.02.11' );
+define( 'DINTERO_HP_VERSION', '2021.02.12' );
 
 
 if ( ! defined( 'DHP_PLUGIN_FILE' ) ) {

--- a/templates/dhp-checkout-embed-express.php
+++ b/templates/dhp-checkout-embed-express.php
@@ -20,6 +20,9 @@ if ( ! $checkout->is_registration_enabled() && $checkout->is_registration_requir
 
 <form name="checkout" class="checkout woocommerce-checkout">
 <?php do_action( 'dhp_before_wrapper' ); ?>
+	<div id="order_review" class="woocommerce-checkout-review-order ritesh">
+		<?php woocommerce_order_review(); ?>
+	</div>
 	<div id="dhp-wrapper" class='embexp col2-set'>
 		<div class="col-1">
 			<?php do_action( 'dhp_payment_tab' ); ?>
@@ -36,9 +39,6 @@ if ( ! $checkout->is_registration_enabled() && $checkout->is_registration_requir
 		</div>
 		
 		
-	</div>
-	<div id="order_review" class="woocommerce-checkout-review-order ritesh">
-		<?php woocommerce_order_review(); ?>
 	</div>
 	<?php do_action( 'dhp_after_wrapper' ); ?>
 </form>

--- a/templates/dhp-checkout-embed-express.php
+++ b/templates/dhp-checkout-embed-express.php
@@ -20,7 +20,7 @@ if ( ! $checkout->is_registration_enabled() && $checkout->is_registration_requir
 
 <form name="checkout" class="checkout woocommerce-checkout">
 <?php do_action( 'dhp_before_wrapper' ); ?>
-	<div id="order_review" class="woocommerce-checkout-review-order ritesh">
+	<div id="order_review" class="woocommerce-checkout-review-order">
 		<?php woocommerce_order_review(); ?>
 	</div>
 	<div id="dhp-wrapper" class='embexp col2-set'>


### PR DESCRIPTION
Moving order review before checkout on mobile after some complaints that customers have to scroll down to see it and to change shipping.

![image](https://user-images.githubusercontent.com/509817/107685695-94b10e80-6ca4-11eb-8ac6-d6b46ce701c2.png)
