### PR TITLE
Show indication that checkout failed to load

### DIFF
--- a/includes/class-wc-gateway-dintero-hp.php
+++ b/includes/class-wc-gateway-dintero-hp.php
@@ -321,7 +321,20 @@ class WC_Gateway_Dintero_HP extends WC_Payment_Gateway {
 			// 	'default'     => 'yes',
 			// 	'desc_tip'    => true,
 			// ),
-			'branding_title'                => array(
+            'express_shipping_options_title' => array(
+                'title' => __('Checkout Express Shipping Options'),
+                'type' => 'title',
+                'description' => ''
+            ),
+            'express_shipping_options' => array(
+                'title' => __('Enable:'),
+                'label' => __('Enable embedded shipping options'),
+                'type' => 'checkbox',
+                'description' => __('Enables shipping options embedded in Dintero Checkout Express'),
+                'default' => 'no',
+                'desc_tip' => true,
+            ),
+            'branding_title'                => array(
 				'title'       => __( 'Branding:' ),
 				'type'        => 'title',
 				'description' => ''


### PR DESCRIPTION
When session creation fails, do the following:

- Give request_id to user for easier error handling
- Log more info to JavaScript console