### PR TITLE
Fixing error when creating redirect session

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .idea/
+.wp/
+.vendor/

--- a/includes/class-dintero-hp-adapter.php
+++ b/includes/class-dintero-hp-adapter.php
@@ -62,8 +62,8 @@ class Dintero_HP_Adapter
 	public function get_access_token()
 	{
 		$is_sandbox = WCDHP()->setting()->get('test_mode') === 'yes';
-		$client_id = WCDHP()->setting()->get($is_sandbox ? 'test_client_id' : 'client_id' );
-		$client_secret = WCDHP()->setting()->get($is_sandbox ? 'test_client_secret' : 'client_secret');
+		$client_id = WCDHP()->setting()->get($is_sandbox ? 'test_client_id' : 'production_client_id' );
+		$client_secret = WCDHP()->setting()->get($is_sandbox ? 'test_client_secret' : 'production_client_secret');
 		$account_id = ($is_sandbox ? 'T' : 'P') . WCDHP()->setting()->get('account_id');
 		$request = $this->_init_request()
 			->set_auth_params($client_id, $client_secret)


### PR DESCRIPTION
The function `get_access_token` fetched the wrong setting, `client_id` instead of `production_client_id`. When being used in session initialization, this function returned an empty access token, and we're unable to create the session.

I think this function has never worked, and it just happened to not being called.

Blame: #57 