### PR TITLE
Fix exit code from phpunit.sh script on test failure

### DIFF
--- a/bin/phpunit.sh
+++ b/bin/phpunit.sh
@@ -1,8 +1,13 @@
 #!/usr/bin/env bash
+set -e
 
 if [[ $RUN_PHPCS == 1 || $SHOULD_DEPLOY == 1 ]]; then
 	exit
 fi
 
-if [ -f "phpunit.phar" ]; then php phpunit.phar --coverage-clover clover.xml -c phpunit.xml.dist; else ./vendor/bin/phpunit --coverage-clover clover.xml; fi;
-pwd
+if [ -f "phpunit.phar" ]; then
+	php phpunit.phar \
+		--coverage-clover clover.xml -c phpunit.xml.dist;
+else
+	./vendor/bin/phpunit --coverage-clover clover.xml;
+fi;


### PR DESCRIPTION
The last command `pwd` cause any test failure to not be reported
as the result from the script was a success
