### PR TITLE
Fix issue for embedded shipping options where order is not updated after cart update

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -3,7 +3,7 @@ Contributors: moogruppen, dintero
 Tags: woocommerce, Payment, Checkout, Vipps, Visa, Mastercard, Invoice, Instalment, Installment, Swish, Gateway, payment, dintero, Betalingsløsning, Checkout, Betaling, Vipps, Visa, Mastercard, Faktura, Delbetaling, Swish, Betalingsgateway, vipps, Betaling, nettbutikk
 Donate link: https://dintero.com
 Requires at least: 4.0
-Tested up to: 5.7
+Tested up to: 5.8
 Requires PHP: 5.6
 WC requires at least: 3.4.0
 WC tested up to: 4.0.0
@@ -42,6 +42,10 @@ When you install Dintero Checkout, you need to head to the settings page to star
 
 
 == Changelog ==
+
+2021.08.17
+
+* Fix issue for embedded shipping options where order is not updated after cart update
 
 2021.08.13
 

--- a/dintero-hp.php
+++ b/dintero-hp.php
@@ -2,7 +2,7 @@
 /**
 Plugin Name: Dintero Checkout
 Description: Dintero Checkout - Express Checkout
-Version:     2021.08.13
+Version:     2021.08.17
 Author:      Dintero
 Author URI:  mailto:integration@dintero.com
 Text Domain: dintero-hp
@@ -13,7 +13,7 @@ Domain Path: /languages
 
 defined( 'ABSPATH' ) || exit;
 
-define( 'DINTERO_HP_VERSION', '2021.08.13' );
+define( 'DINTERO_HP_VERSION', '2021.08.17' );
 
 
 

--- a/includes/class-wc-dintero-hp-checkout.php
+++ b/includes/class-wc-dintero-hp-checkout.php
@@ -1183,8 +1183,7 @@ class WC_Dintero_HP_Checkout extends WC_Checkout
 					var homeUrl = \"" .home_url(). "\";
 					document.addEventListener('DOMContentLoaded', function(event) { 
 					  	jQuery( document ).on( 'updated_checkout', function(){
-					  		if(checkoutSession && isShippingInIframe == 0){
-					  			// If shipping in Iframe then we dont need the lock session 
+					  		if(checkoutSession){
 								checkoutSession.lockSession();
 							}
 						});


### PR DESCRIPTION
When embedding shipping options in the checkout, updating the cart wouldn't update the Dintero session, which would lead to a mismatch between the order price and the session price.