### PR TITLE
Fix wrong note when payment has been auto-captured

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -43,6 +43,10 @@ When you install Dintero Checkout, you need to head to the settings page to star
 
 == Changelog ==
 
+2021.09.24
+
+* Fix wrong order note when payment was auto-captured
+
 2021.09.21
 
 * Handle race condition between callback and redirect

--- a/dintero-hp.php
+++ b/dintero-hp.php
@@ -2,7 +2,7 @@
 /**
 Plugin Name: Dintero Checkout
 Description: Dintero Checkout - Express Checkout
-Version:     2021.09.21
+Version:     2021.09.24
 Author:      Dintero
 Author URI:  mailto:integration@dintero.com
 Text Domain: dintero-hp
@@ -13,7 +13,7 @@ Domain Path: /languages
 
 defined( 'ABSPATH' ) || exit;
 
-define( 'DINTERO_HP_VERSION', '2021.09.21' );
+define( 'DINTERO_HP_VERSION', '2021.09.24' );
 
 
 

--- a/includes/class-wc-gateway-dintero-hp.php
+++ b/includes/class-wc-gateway-dintero-hp.php
@@ -1502,10 +1502,12 @@ class WC_Gateway_Dintero_HP extends WC_Payment_Gateway
 					$note = __( 'Payment captured via Dintero. Transaction ID: ' ) . $transaction_id;
 					$this->payment_complete( $order, $transaction_id, $note );
 				} else {
-
 					$note = __( 'Payment capture failed at Dintero. Transaction ID: ' ) . $transaction_id;
 					$order->add_order_note( $note );
 				}
+			} else if ('CAPTURED' === $transaction['status']) {
+				$note = __( 'Payment captured via Dintero, already captured from before. Transaction ID: ' ) . $transaction_id;
+				$this->payment_complete( $order, $transaction_id, $note );
 			} else {
 				$note = sprintf(
 						'Payment capture failed. Order and transaction amounts do not match. Transaction amount: %s. Order amount: %s. ',

--- a/tests/phpunit/test-class-wc-gateway-dintero-hp.php
+++ b/tests/phpunit/test-class-wc-gateway-dintero-hp.php
@@ -185,16 +185,12 @@ class WC_Gateway_Dintero_HP_Test extends WP_UnitTestCase {
 		$checkout = new WC_Gateway_Dintero_HP();
 		$adapter_stub = $this->createMock(Dintero_HP_Adapter::class);
 
-		// These together should of course be 320.04, but were 320.03 previously
 		$shipping_cost = 256.03;
 		$shipping_tax = 64.01;
 
-		$fee_item = new WC_Order_Item_Fee();
-		$fee_item->set_name( 'extra_fee' );
-		$fee_item->set_total( 100 );
 		$product = WC_Helper_Product::create_simple_product();
 
-		$order = WC_Helper_Order::create_order(1, $product, $shipping_cost, $shipping_tax, array($fee_item));
+		$order = WC_Helper_Order::create_order(1, $product, $shipping_cost, $shipping_tax);
 		$order->set_transaction_id('P12345678.abcdefghijklmnop');
 		$order->save();
 

--- a/tests/phpunit/test-class-wc-gateway-dintero-hp.php
+++ b/tests/phpunit/test-class-wc-gateway-dintero-hp.php
@@ -181,5 +181,52 @@ class WC_Gateway_Dintero_HP_Test extends WP_UnitTestCase {
 		$this->assertEquals('Payment captured via Dintero. Transaction ID: P12345678.abcdefghijklmnop', end($note)->content);
 	}
 
+	public function test_capture_on_auto_captured() {
+		$checkout = new WC_Gateway_Dintero_HP();
+		$adapter_stub = $this->createMock(Dintero_HP_Adapter::class);
+
+		// These together should of course be 320.04, but were 320.03 previously
+		$shipping_cost = 256.03;
+		$shipping_tax = 64.01;
+
+		$fee_item = new WC_Order_Item_Fee();
+		$fee_item->set_name( 'extra_fee' );
+		$fee_item->set_total( 100 );
+		$product = WC_Helper_Product::create_simple_product();
+
+		$order = WC_Helper_Order::create_order(1, $product, $shipping_cost, $shipping_tax, array($fee_item));
+		$order->set_transaction_id('P12345678.abcdefghijklmnop');
+		$order->save();
+
+		$captured_transaction = array(
+			'amount' => 5000,
+			'merchant_reference' => '',
+			'merchant_reference_2' => $order->get_id(),
+			'status' => 'CAPTURED',
+		);
+
+		$adapter_stub
+			->expects($this->exactly(1))
+			->method('get_transaction')
+			->willReturn($captured_transaction);
+
+		$adapter_stub
+			->expects($this->exactly(0))
+			->method('capture_transaction')
+			->willReturn($captured_transaction);
+		$checkout::$_adapter = $adapter_stub;
+
+		$checkout->check_status($order->get_id(), '', 'completed');
+
+		// check that the order has been updated with the new status
+		$note = wc_get_order_notes(array(
+				'order_id' => $order->get_id(),
+				'limit'    => 10,
+				'orderby'  => 'date_created_gmt',
+			)
+		);
+		$this->assertEquals('Payment captured via Dintero, already captured from before. Transaction ID: P12345678.abcdefghijklmnop', end($note)->content);
+	}
+
 
 }


### PR DESCRIPTION
When capture is not attempted because the transaction was captured from before, this was marked as a capture failure. Mark this with a note saying it was capture from before.