### PR TITLE
Add discount codes to session and use when creating order from callback

### DIFF
--- a/includes/class-wc-dintero-hp-ajax.php
+++ b/includes/class-wc-dintero-hp-ajax.php
@@ -364,6 +364,9 @@ class WC_AJAX_HP {
 
 		if(!$order && $transaction['merchant_reference_2'] == '') {
 			$coupon_codes = isset($session_data['applied_coupons']) ? maybe_unserialize($session_data['applied_coupons']) : array();
+			if (count($coupon_codes) == 0 && isset($session['order']['discount_codes']) && count($session['order']['discount_codes']) > 0) {
+				$coupon_codes = $session['order']['discount_codes'];
+			}
 			$items = $transaction['items'];
 			$order = wc_create_order( array( 'status' => 'pending' ) );
 			$order->set_transaction_id( $transaction_id );
@@ -534,7 +537,6 @@ class WC_AJAX_HP {
 				) {
 
 					WC()->session->set( 'order_awaiting_payment', null );
-
 					if ( 'AUTHORIZED' === $transaction['status'] ) {
 
 						$note = __( 'Transaction authorized via Dintero. Change order status to the manual capture status or the additional status that are selected in the settings page to capture the funds. Transaction ID: ' ) . $transaction_id;

--- a/includes/class-wc-dintero-hp-checkout.php
+++ b/includes/class-wc-dintero-hp-checkout.php
@@ -1982,6 +1982,7 @@ class WC_Dintero_HP_Checkout extends WC_Checkout
 				'currency'           => $currency,
 				'merchant_reference' => '',
 				'items'              => $this->order_lines,
+				'discount_codes'	 => WC()->cart->get_applied_coupons(),
 			)
 		);
 

--- a/includes/class-wc-gateway-dintero-hp.php
+++ b/includes/class-wc-gateway-dintero-hp.php
@@ -932,36 +932,10 @@ class WC_Gateway_Dintero_HP extends WC_Payment_Gateway
 	 * Update transaction with woocommerce Order Number.
 	 */
 	private function update_transaction( $transaction_id , $order_id ) {
-
-
-		$access_token = $this->get_access_token();
-		$api_endpoint = $this->checkout_endpoint . '/transactions';
-
-
-		$headers = array(
-
-			'Content-type'  => 'application/json; charset=utf-8',
-			'Accept'        => 'application/json',
-			'Authorization' => 'Bearer ' . $access_token,
-
-			'Dintero-System-Name' => 'woocommerce',
-			'Dintero-System-Version' =>  WC()->version,
-			'Dintero-System-Plugin-Name' => 'Dintero.Checkout.WooCommerce',
-			'Dintero-System-Plugin-Version' => DINTERO_HP_VERSION
-		);
-
 		$payload = array(
 			'merchant_reference_2' => (string)$order_id
 		);
-		$url = $api_endpoint . '/' . $transaction_id;
-		$response = wp_remote_request( $url, array(
-			'method'    => 'PUT',
-			'headers'   => $headers,
-			'body'      => json_encode( $payload )
-		) );
-		$response_body  = wp_remote_retrieve_body( $response );
-		$transaction = json_decode( $response_body, true );
-		return $transaction;
+		return self::_adapter()->update_transaction($transaction_id, $payload);
 	}
 
 	/**


### PR DESCRIPTION
If a customer performs two payments, one with a callback and one with redirect, if the redirect happens before the callback, the session is removed from the database, and the discount code is not persisted.

This leads to the order not having the correct amount and no reference to the discount.

We solve this by storing the discount_codes on the session.