### PR TITLE
Fixes bug when discount codes are associative arrays

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -43,7 +43,7 @@ When you install Dintero Checkout, you need to head to the settings page to star
 
 == Changelog ==
 
-pending
+2021.11.01
 
 * Fixes bug when discount_codes are associative arrays
 

--- a/README.txt
+++ b/README.txt
@@ -43,6 +43,10 @@ When you install Dintero Checkout, you need to head to the settings page to star
 
 == Changelog ==
 
+pending
+
+* Fixes bug when discount_codes are associative arrays
+
 2021.10.28
 
 * Fixes bug from 2021.10.27 when shipping option contains no metadata

--- a/dintero-hp.php
+++ b/dintero-hp.php
@@ -2,7 +2,7 @@
 /**
 Plugin Name: Dintero Checkout
 Description: Dintero Checkout - Express Checkout
-Version:     2021.10.28
+Version:     2021.11.01
 Author:      Dintero
 Author URI:  mailto:integration@dintero.com
 Text Domain: dintero-hp
@@ -13,7 +13,7 @@ Domain Path: /languages
 
 defined( 'ABSPATH' ) || exit;
 
-define( 'DINTERO_HP_VERSION', '2021.10.28' );
+define( 'DINTERO_HP_VERSION', '2021.11.01' );
 
 
 

--- a/includes/class-wc-dintero-hp-checkout.php
+++ b/includes/class-wc-dintero-hp-checkout.php
@@ -1983,7 +1983,7 @@ class WC_Dintero_HP_Checkout extends WC_Checkout
 				'currency'           => $currency,
 				'merchant_reference' => '',
 				'items'              => $this->order_lines,
-				'discount_codes'	 => WC()->cart->get_applied_coupons(),
+				'discount_codes'	 => Dintero_HP_Helper::instance()->convert_to_dintero_discounts(WC()->cart->get_applied_coupons()),
 			)
 		);
 
@@ -2172,7 +2172,7 @@ class WC_Dintero_HP_Checkout extends WC_Checkout
 				'amount'             => $order_total_amount ,
 				'vat_amount'         => $order_tax_amount ,
 				'currency'           => $currency,
-				'discount_codes'	=> WC()->cart->get_applied_coupons(),
+				'discount_codes'	=> Dintero_HP_Helper::instance()->convert_to_dintero_discounts(WC()->cart->get_applied_coupons()),
 				'merchant_reference' => '',
 				'shipping_address'   => array(
 					'first_name'   => (string) WC()->checkout()->get_value( 'shipping_first_name' ),

--- a/includes/class-wc-dintero-hp-helper.php
+++ b/includes/class-wc-dintero-hp-helper.php
@@ -94,7 +94,7 @@ class Dintero_HP_Helper
 		if (is_null($applied_coupons)) {
 			return array();
 		}
-		$discount_codes = [];
+		$discount_codes = array();
 		foreach ($applied_coupons as $coupon) {
 			$discount_codes[] = $coupon;
 		}

--- a/includes/class-wc-dintero-hp-helper.php
+++ b/includes/class-wc-dintero-hp-helper.php
@@ -90,6 +90,17 @@ class Dintero_HP_Helper
 		return $meta_data;
 	}
 
+	public function convert_to_dintero_discounts($applied_coupons) {
+		if (is_null($applied_coupons)) {
+			return array();
+		}
+		$discount_codes = [];
+		foreach ($applied_coupons as $coupon) {
+			$discount_codes[] = $coupon;
+		}
+		return $discount_codes;
+	}
+
 	private function is_associative_array(array $arr) {
 		if (array() === $arr) {
 			return false;

--- a/tests/phpunit/test-class-wc-dintero-hp-helper.php
+++ b/tests/phpunit/test-class-wc-dintero-hp-helper.php
@@ -45,5 +45,39 @@ class Dintero_HP_Helper_Test extends WP_UnitTestCase {
 		$this->assertEquals(array('a' => 'b'), $dintero_meta);
 	}
 
+	/**
+	 * @group helper
+	 */
+	public function test_convert_discount_object() {
+		$helper = Dintero_HP_Helper::instance();
+		
+		$discount_codes = $helper->convert_to_dintero_discounts(array(
+			'2' => 'b'
+		));
+		$this->assertEquals(array('b'), $discount_codes);
+	}
+	
+	/**
+	 * @group helper
+	 */
+	public function test_convert_discount_null() {
+		$helper = Dintero_HP_Helper::instance();
+		
+		$discount_codes = $helper->convert_to_dintero_discounts(null);
+		$this->assertEquals(array(), $discount_codes);
+	}
+	
+	/**
+	 * @group helper
+	 */
+	public function test_convert_discount_normal_array() {
+		$helper = Dintero_HP_Helper::instance();
+		
+		$discount_codes = $helper->convert_to_dintero_discounts(array(
+			'a', 'b'
+		));
+		$this->assertEquals(array('a', 'b'), $discount_codes);
+	}
+
 
 }


### PR DESCRIPTION
Session creation will fail if the discount codes added are not arrays. Associative arrays will translate to json objects, and we get the following error message:

```json
{
  "body": {
    "error": {
      "code": "INVALID_REQUEST_PARAMETER",
      "message": "Invalid parameter (options): Value failed JSON Schema validation",
      "errors": [
        {
          "code": "INVALID_TYPE",
          "params": [
            "array",
            "object"
          ],
          "message": "Expected type array but found type object",
          "path": [
            "order",
            "discount_codes"
          ]
        }
      ]
    }
  },
  "statusCode": 400
}
```

Convert associative arrays to sequential arrays to avoid this.