### PR TITLE
Adjust merchant_reference checks

### DIFF
--- a/includes/class-wc-dintero-hp-ajax.php
+++ b/includes/class-wc-dintero-hp-ajax.php
@@ -1033,12 +1033,12 @@ class WC_AJAX_HP {
 					$method_id = $method->id;
 					$method_name = $method->label;
 					$tax_display = get_option('woocommerce_tax_display_cart');
-					$method_price = intval(round($method->cost, 2) * 100);
+					$method_price = Dintero_HP_Helper::instance()->to_dintero_amount($method->cost, 2);
 					if ( array_sum($method->taxes) > 0 && ('excl' !== $tax_display) ) {
-						$method_tax_amount = intval(round(array_sum($method->taxes), wc_get_rounding_precision()) * 100);
+						$method_tax_amount = Dintero_HP_Helper::instance()->to_dintero_amount(array_sum($method->taxes), wc_get_rounding_precision());
 						$method_tax_rate = intval(round((array_sum($method->taxes) / $method->cost) * 100, 2));
 					} else {
-						$method_tax_amount = intval(round(array_sum($method->taxes), wc_get_price_decimals()) * 100);
+						$method_tax_amount = Dintero_HP_Helper::instance()->to_dintero_amount(array_sum($method->taxes), wc_get_price_decimals());
 						$method_tax_rate = Dintero_HP_Helper::instance()->get_shipping_tax_rate();
 					}
 

--- a/includes/class-wc-dintero-hp-ajax.php
+++ b/includes/class-wc-dintero-hp-ajax.php
@@ -570,11 +570,11 @@ class WC_AJAX_HP {
 			);
 			if (is_wp_error($update_response)) {
 				$updated_transaction = self::_adapter()->get_transaction($transaction_id);
-				if (isset($updated_transaction['merchant_reference_2'])) {
+				if (isset($updated_transaction['merchant_reference_2']) && !empty($updated_transaction['merchant_reference_2'])) {
 					$fail_reason = __( 'Duplicate order of order ' ) . $updated_transaction['merchant_reference_2'] . '.';
 					self::failed_order( $order, $transaction_id, $fail_reason );
 				} else {
-					$fail_reason = __( 'Failed updating transaction with order_id ' ) . '.';
+					$fail_reason = __( 'Failed updating transaction with order_id. This means that it will be harder to find the order in the settlements. ' ) . '.';
 					$order->add_order_note( $fail_reason );
 
 					$update_response_retry = self::_adapter()->update_transaction(
@@ -584,6 +584,8 @@ class WC_AJAX_HP {
 					if (is_wp_error($update_response_retry)) {
 						$fail_reason = __( 'Failed updating transaction with order_id. Will stop trying ' ) . '.';
 						$order->add_order_note( $fail_reason );
+					} else {
+						$order->add_order_note( 'Order id was updated after retry');
 					}
 				}
 			}

--- a/includes/class-wc-gateway-dintero-hp.php
+++ b/includes/class-wc-gateway-dintero-hp.php
@@ -1007,11 +1007,7 @@ class WC_Gateway_Dintero_HP extends WC_Payment_Gateway
 			$transaction_id = $order->get_transaction_id();
 			$transaction = self::_adapter()->get_transaction($transaction_id);
 
-			$merchant_reference = absint( strval(trim($transaction['merchant_reference'])));
-			$merchant_reference_2 = absint( strval(trim($transaction['merchant_reference_2'])));
-
-			if (  ($merchant_reference === $order_id  || $merchant_reference_2 === $order_id ) &&
-				 array_key_exists( 'status', $transaction ) &&
+			if ( array_key_exists( 'status', $transaction ) &&
 				 array_key_exists( 'amount', $transaction ) &&
 				 ( 'CAPTURED' === $transaction['status'] ||
 				 'PARTIALLY_CAPTURED' === $transaction['status'] ||

--- a/includes/class-wc-gateway-dintero-hp.php
+++ b/includes/class-wc-gateway-dintero-hp.php
@@ -792,11 +792,11 @@ class WC_Gateway_Dintero_HP extends WC_Payment_Gateway
 			$transaction = WCDHP()->checkout()->update_transaction($dintero_order_transaction_id, $order_id);
 			if (is_wp_error($transaction)) {
 				$updated_transaction = self::_adapter()->get_transaction($dintero_order_transaction_id);
-				if (isset($updated_transaction['merchant_reference_2'])) {
+				if (isset($updated_transaction['merchant_reference_2']) && !empty($updated_transaction['merchant_reference_2'])) {
 					$fail_reason = __( 'Duplicate order of order ' ) . $updated_transaction['merchant_reference_2'] . '.';
 					self::failed_order( $order, $dintero_order_transaction_id, $fail_reason );
 				} else {
-					$fail_reason = __( 'Failed updating transaction with order_id ' ) . '.';
+					$fail_reason = __( 'Failed updating transaction with order_id. This means that it will be harder to find the order in the settlements. ' ) . '.';
 					$order->add_order_note( $fail_reason );
 
 					$update_response_retry = WCDHP()->checkout()->update_transaction($dintero_order_transaction_id, $order_id);
@@ -804,6 +804,8 @@ class WC_Gateway_Dintero_HP extends WC_Payment_Gateway
 					if (is_wp_error($update_response_retry)) {
 						$fail_reason = __( 'Failed updating transaction with order_id. Will stop trying ' ) . '.';
 						$order->add_order_note( $fail_reason );
+					} else {
+						$order->add_order_note( 'Order id was updated after retry');
 					}
 				}
 			}

--- a/includes/class-wc-gateway-dintero-hp.php
+++ b/includes/class-wc-gateway-dintero-hp.php
@@ -797,7 +797,14 @@ class WC_Gateway_Dintero_HP extends WC_Payment_Gateway
 					self::failed_order( $order, $dintero_order_transaction_id, $fail_reason );
 				} else {
 					$fail_reason = __( 'Failed updating transaction with order_id ' ) . '.';
-					self::failed_order( $order, $dintero_order_transaction_id, $fail_reason );
+					$order->add_order_note( $fail_reason );
+
+					$update_response_retry = WCDHP()->checkout()->update_transaction($dintero_order_transaction_id, $order_id);
+
+					if (is_wp_error($update_response_retry)) {
+						$fail_reason = __( 'Failed updating transaction with order_id. Will stop trying ' ) . '.';
+						$order->add_order_note( $fail_reason );
+					}
 				}
 			}
 
@@ -1006,8 +1013,8 @@ class WC_Gateway_Dintero_HP extends WC_Payment_Gateway
 			if (  ($merchant_reference === $order_id  || $merchant_reference_2 === $order_id ) &&
 				 array_key_exists( 'status', $transaction ) &&
 				 array_key_exists( 'amount', $transaction ) &&
-				 ( 'CAPTURED' === $transaction['status'] || 
-				 'PARTIALLY_CAPTURED' === $transaction['status'] || 
+				 ( 'CAPTURED' === $transaction['status'] ||
+				 'PARTIALLY_CAPTURED' === $transaction['status'] ||
 				 'PARTIALLY_REFUNDED' === $transaction['status'] ) ) {
 
 				if ( empty( $amount ) ) {
@@ -1067,24 +1074,7 @@ class WC_Gateway_Dintero_HP extends WC_Payment_Gateway
 				return false;
 			}
 			$transaction = self::_adapter()->get_transaction($transaction_id);
-
-			$merchant_reference = absint( strval(trim($transaction['merchant_reference'])));
-			$merchant_reference_2 = absint( strval(trim($transaction['merchant_reference_2'])));
-
-
-			if ( $merchant_reference === $order_id  || $merchant_reference_2 === $order_id ) {
-				$this->capture( $order, $transaction );
-			} else {
-				$order->add_order_note(__(
-					sprintf(
-						'Could not capture transaction: Merchant reference is wrong (%s, %s). Contact integration@dintero.com with order information. Changing status to on-hold.',
-						$merchant_reference, $merchant_reference_2,
-					)
-				));
-				$order->set_status( 'on-hold' );
-				$order->save();
-				$order->save_meta_data();
-			}
+			$this->capture( $order, $transaction );
 		}
 	}
 

--- a/tests/phpunit/test-ajax.php
+++ b/tests/phpunit/test-ajax.php
@@ -202,6 +202,96 @@ class Ajax_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	* @group retry
+	*/
+	public function test_retry_when_updating() {
+		$ajax = new WC_AJAX_HP();
+		$shipping_product = WC_Helper_Product::create_simple_product();
+		$another_product = WC_Helper_Product::create_simple_product();
+
+		// Mock query parameters
+		$_GET['transaction_id'] = 'P87654321.55wd4cLGiHcyNrfnCmzeqH';
+		$_GET['session_id'] = 'P87654321.55wd3zjzVCkXXoVFv518q7';
+
+		$customer_id = WC()->session->get_customer_id();
+		// mock transaction returned from Dintero /v1/transactions/{transaction_id}
+		$transaction = array(
+			'id' => 'P87654321.55wd4cLGiHcyNrfnCmzeqH',
+			'payment_product' => 'payex',
+			'merchant_reference' => '',
+			'merchant_reference_2' => '',
+			'status' => 'AUTHORIZED',
+			'items' => array(
+				array(
+					'id' => $shipping_product->get_id(),
+					'amount' => 500,
+					'vat_amount' => 0,
+					'description' => 'shipping',
+				),
+				array(
+					'id' => $another_product->get_id(),
+					'amount' => 500,
+					'vat_amount' => 20,
+					'description' => 'shipping',
+					'quantity' => 1
+				)
+			),
+			'amount' => 1000,
+			'shipping_option' => array(
+				'id' => $shipping_product->get_id(),
+				'line_id' => $shipping_product->get_id(),
+				'operator_product_id' => $shipping_product->get_id()
+			),
+			'shipping_address' => array(
+				'first_name' => 'Mickey',
+				'last_name' => 'Mouse',
+				'country' => 'NO',
+				'address_line' => 'Scrooge Street 1',
+				'postal_place' => 'Andeby',
+				'postal_code' => '1337',
+				'phone_number' => '+4748059134',
+				'email' => 'mickey@disney.com'
+			)
+		);
+		$updated_transaction = array(
+			'merchant_reference_2' => 'other_order'
+		);
+		$session = array(
+			'order' => array(
+				'vat_amount' => 40
+			),
+			'metadata' => array(
+				'woo_customer_id' => $customer_id
+			),
+		);
+		$adapter_stub = $this->createMock(Dintero_HP_Adapter::class);
+		$adapter_stub->method('get_transaction')
+			->will( $this->onConsecutiveCalls($transaction, $transaction));
+		$adapter_stub->method('get_session')->willReturn($session);
+		$adapter_stub->method('update_transaction')
+			->will( $this->onConsecutiveCalls(new WP_Error(400, 'body' . 'error' ), $updated_transaction ));
+		$ajax::$_adapter = $adapter_stub;
+
+		// perform callback to create order
+		$ajax->dhp_create_order();
+
+		// check that the order has been updated with the new status
+		$updated_order = wc_get_orders(array(
+			'billing_first_name' => 'Mickey',
+			'limit' => 1,
+			'order' => 'DESC',
+		))[0];
+		$this->assertEquals($updated_order->get_status(), 'processing');
+		$last_note = wc_get_order_notes(array(
+			'order_id' => $updated_order->get_id(),
+			'limit' => 1,
+			'order' => 'DESC',
+			'type' => 'internal',
+		))[0];
+		$this->assertContains('Order id was updated after retry', $last_note->content);
+	}
+
+	/**
 	 * @group create_order_from_transaction
 	 */
 	public function test_create_order_from_transaction() {


### PR DESCRIPTION
We will sometimes get random errors when trying to update merchant_reference_2 on the transaction.

Trying to adjust the behaviour a little bit:

1) If the call fails, retry once
2) If it still fails, don't fail the order, but keep it open
3) When capturing, don't check that the merchant_reference is equal to the order_id, as we already can be sure that the transaction id is correct
