### PR TITLE
Adjust rules for allowing completion on already refunded-transactions

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -6,7 +6,7 @@ Requires at least: 4.0
 Tested up to: 5.8
 Requires PHP: 5.6
 WC requires at least: 3.4.0
-WC tested up to: 4.0.0
+WC tested up to: 5.9.0
 Stable tag: trunk
 License: GPLv3 or later
 License URI: http://www.gnu.org/licenses/gpl-3.0.html

--- a/README.txt
+++ b/README.txt
@@ -43,6 +43,10 @@ When you install Dintero Checkout, you need to head to the settings page to star
 
 == Changelog ==
 
+2021.12.01
+
+* Adjust rules for completing when transaction already refunded
+
 2021.11.29
 
 * Allow capture even if merchant_reference doesn't match

--- a/dintero-hp.php
+++ b/dintero-hp.php
@@ -2,7 +2,7 @@
 /**
 Plugin Name: Dintero Checkout
 Description: Dintero Checkout - Express Checkout
-Version:     2021.11.29
+Version:     2021.12.01
 Author:      Dintero
 Author URI:  mailto:integration@dintero.com
 Text Domain: dintero-hp
@@ -13,7 +13,7 @@ Domain Path: /languages
 
 defined( 'ABSPATH' ) || exit;
 
-define( 'DINTERO_HP_VERSION', '2021.11.29' );
+define( 'DINTERO_HP_VERSION', '2021.12.01' );
 
 
 

--- a/includes/class-wc-dintero-hp.php
+++ b/includes/class-wc-dintero-hp.php
@@ -247,8 +247,6 @@ final class WC_Dintero_HP {
 					$last_refund_succeeded = $note->id;
 				} else if (strpos( $note->content, 'Dintero transaction has already been captured, and now has status (REFUNDED).') !== false ) {
 					$last_refund_succeeded = $note->id;
-				} else if (strpos( $note->content, 'Dintero transaction has already been captured, and now has status (PARTIALLY_CAPTURED_REFUNDED).') !== false ) {
-					$last_refund_succeeded = $note->id;
 				}
 			}
 			if ($last_cancel > -1) {

--- a/includes/class-wc-dintero-hp.php
+++ b/includes/class-wc-dintero-hp.php
@@ -243,6 +243,12 @@ final class WC_Dintero_HP {
 					$last_on_hold = $note->id;
 				} else if (strpos( $note->content, 'Transaction cancelled via Dintero') !== false) {
 					$last_cancel = $note->id;
+				} else if (strpos( $note->content, 'Dintero transaction has already been captured, and now has status (PARTIALLY_REFUNDED).') !== false ) {
+					$last_refund_succeeded = $note->id;
+				} else if (strpos( $note->content, 'Dintero transaction has already been captured, and now has status (REFUNDED).') !== false ) {
+					$last_refund_succeeded = $note->id;
+				} else if (strpos( $note->content, 'Dintero transaction has already been captured, and now has status (PARTIALLY_CAPTURED_REFUNDED).') !== false ) {
+					$last_refund_succeeded = $note->id;
 				}
 			}
 			if ($last_cancel > -1) {
@@ -465,7 +471,7 @@ final class WC_Dintero_HP {
 						is_express: 1
 					};
 					var url = \"".home_url().'?dhp-ajax=create_order'."\";
-							    
+
 					jQuery.ajax({
 						type: 'POST',
 						url: url,

--- a/includes/class-wc-gateway-dintero-hp.php
+++ b/includes/class-wc-gateway-dintero-hp.php
@@ -1108,8 +1108,7 @@ class WC_Gateway_Dintero_HP extends WC_Payment_Gateway
 			};
 
 			if ($transaction_status === 'REFUNDED' ||
-				$transaction_status === 'PARTIALLY_REFUNDED' ||
-				$transaction_status === 'PARTIALLY_CAPTURED_REFUNDED') {
+				$transaction_status === 'PARTIALLY_REFUNDED') {
 				$order->add_order_note(__(
 					sprintf(
 						'Dintero transaction has already been captured, and now has status (%s).',


### PR DESCRIPTION
* Adjust rules for completing when transaction already refunded
* Release 2021.12.01

Some merchants have problems when trying to complete payments that already are refunded. Allow them to complete it.
