### PR TITLE
Improve callback from redirect-payment when amounts differ

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -43,6 +43,10 @@ When you install Dintero Checkout, you need to head to the settings page to star
 
 == Changelog ==
 
+2021.12.09
+
+* Fix expired orders by improving callback handling on redirect payments.
+
 2021.12.01
 
 * Adjust rules for completing when transaction already refunded

--- a/dintero-hp.php
+++ b/dintero-hp.php
@@ -2,7 +2,7 @@
 /**
 Plugin Name: Dintero Checkout
 Description: Dintero Checkout - Express Checkout
-Version:     2021.12.01
+Version:     2021.12.09
 Author:      Dintero
 Author URI:  mailto:integration@dintero.com
 Text Domain: dintero-hp
@@ -13,7 +13,7 @@ Domain Path: /languages
 
 defined( 'ABSPATH' ) || exit;
 
-define( 'DINTERO_HP_VERSION', '2021.12.01' );
+define( 'DINTERO_HP_VERSION', '2021.12.09' );
 
 
 

--- a/includes/class-wc-gateway-dintero-hp.php
+++ b/includes/class-wc-gateway-dintero-hp.php
@@ -1361,12 +1361,13 @@ class WC_Gateway_Dintero_HP extends WC_Payment_Gateway
 					 array_key_exists( 'amount', $transaction )) {
 
 					if ($transaction['amount'] < $amount - 1 ) {
-						$note = sprintf(
-							'Order was authorized with a different amount, so manual handling is required. When captured in Dintero Backoffice, the order can be marked as completed. Transaction amount: %s. Order amount: %s.',
+						$hold_reason = sprintf(
+							'Order was authorized with a different amount, so manual handling is required. When captured in Dintero Backoffice, the order can be marked as completed. Transaction amount: %s. Order amount: %s. Transaction ID: %s. ',
 							$transaction['amount'],
-							$amount
-						) . $transaction_id;
-						$this->on_hold_order( $order, $transaction_id, $note );
+							$amount,
+							$transaction_id
+						);
+						$this->on_hold_order( $order, $transaction_id, $hold_reason );
 					} else if ( 'AUTHORIZED' === $transaction['status'] ) {
 						$hold_reason = __( 'Transaction authorized via Dintero. Change order status to the manual capture status or the additional status that are selected in the settings page to capture the funds. Transaction ID: ' ) . $transaction_id;
 						$this->process_authorization( $order, $transaction_id, $hold_reason );

--- a/includes/class-wc-gateway-dintero-hp.php
+++ b/includes/class-wc-gateway-dintero-hp.php
@@ -1361,11 +1361,16 @@ class WC_Gateway_Dintero_HP extends WC_Payment_Gateway
 			if ( ! empty( $order ) && $order instanceof WC_Order ) {
 				$amount = absint( strval( floatval( $order->get_total() ) * 100 ) );
 				if ( array_key_exists( 'status', $transaction ) &&
-					 array_key_exists( 'amount', $transaction ) &&
-					 $transaction['amount'] === $amount ) {
+					 array_key_exists( 'amount', $transaction )) {
 
-					if ( 'AUTHORIZED' === $transaction['status'] ) {
-
+					if ($transaction['amount'] < $amount - 1 ) {
+						$note = sprintf(
+							'Failed to authorize order: Order and transaction amounts do not match. Transaction amount: %s. Order amount: %s. ',
+							$transaction['amount'],
+							$amount
+						) . $transaction_id;
+						$this->on_hold_order( $order, $transaction_id, $note );
+					} else if ( 'AUTHORIZED' === $transaction['status'] ) {
 						$hold_reason = __( 'Transaction authorized via Dintero. Change order status to the manual capture status or the additional status that are selected in the settings page to capture the funds. Transaction ID: ' ) . $transaction_id;
 						$this->process_authorization( $order, $transaction_id, $hold_reason );
 					} elseif ( 'CAPTURED' === $transaction['status'] ) {

--- a/includes/class-wc-gateway-dintero-hp.php
+++ b/includes/class-wc-gateway-dintero-hp.php
@@ -931,7 +931,7 @@ class WC_Gateway_Dintero_HP extends WC_Payment_Gateway
 		if ( $current_status === $this->manual_capture_status ||
 			 $current_status === $this->additional_manual_capture_status ) {
 
-			$this->check_capture( $order_id );
+			$this->capture( $order_id );
 		} else {
 			if ( 'cancelled' === $current_status ||
 				 $current_status === $this->additional_cancel_status ) {
@@ -1054,11 +1054,9 @@ class WC_Gateway_Dintero_HP extends WC_Payment_Gateway
 	}
 
 	/**
-	 * Check if payment capture is possible when the order is changed from on-hold to complete or processing
-	 *
-	 * @param int $order_id Order ID.
+	 * Capture Payment.
 	 */
-	private function check_capture( $order_id ) {
+	private function capture( $order_id ) {
 		$order = wc_get_order( $order_id );
 
 		if ( ! empty( $order ) &&
@@ -1071,25 +1069,10 @@ class WC_Gateway_Dintero_HP extends WC_Payment_Gateway
 				$order->save();
 				return false;
 			}
-			$transaction = self::_adapter()->get_transaction($transaction_id);
-			$this->capture( $order, $transaction );
-		}
-	}
 
-	/**
-	 * Capture Payment.
-	 */
-	private function capture( $order, $transaction = null ) {
-		if ( ! empty( $order ) &&
-			 $order instanceof WC_Order &&
-			 $order->get_transaction_id() ) {
-
-			$order_id = $order->get_id();
 
 			$transaction_id = $order->get_transaction_id();
-			if ( empty( $transaction ) ) {
-				$transaction = self::_adapter()->get_transaction($transaction_id);
-			}
+			$transaction = self::_adapter()->get_transaction($transaction_id);
 
 			if (isset($transaction['error'])) {
 				$order->add_order_note(__('Could not capture transaction: ' . $transaction['message'] . '. Changing status to on-hold.'));
@@ -1140,11 +1123,25 @@ class WC_Gateway_Dintero_HP extends WC_Payment_Gateway
 				$items = $this->get_items_to_capture_embed($order);
 			}
 
+			$transaction_amount = $transaction['amount'];
+
+			// We experience unexplainable differences of one cent.
+			// To lessen the impact, we will allow difference of one cent,
+			// and will adjust the capture call accordingly
+			if ($order_total_amount === $transaction_amount + 1 ||
+				$order_total_amount === $transaction_amount - 1) {
+				$order_total_amount = $transaction_amount;
+				$items = array();
+			}
+
 			$payload = array(
 				'amount'            => $order_total_amount,
 				'capture_reference' => strval( $order_id ),
-				'items'             => $items
 			);
+			if (count($items) > 0) {
+				$payload['items'] = $items;
+			}
+
 			$response_array = self::_adapter()->capture_transaction($transaction_id, $payload);
 
 			if ( array_key_exists( 'status', $response_array ) &&

--- a/includes/class-wc-gateway-dintero-hp.php
+++ b/includes/class-wc-gateway-dintero-hp.php
@@ -1362,7 +1362,7 @@ class WC_Gateway_Dintero_HP extends WC_Payment_Gateway
 
 					if ($transaction['amount'] < $amount - 1 ) {
 						$note = sprintf(
-							'Failed to authorize order: Order and transaction amounts do not match. Transaction amount: %s. Order amount: %s. Handle the order manually in the Dintero Backoffice.',
+							'Order was authorized with a different amount, so manual handling is required. When captured in Dintero Backoffice, the order can be marked as completed. Transaction amount: %s. Order amount: %s.',
 							$transaction['amount'],
 							$amount
 						) . $transaction_id;

--- a/includes/class-wc-gateway-dintero-hp.php
+++ b/includes/class-wc-gateway-dintero-hp.php
@@ -1365,7 +1365,7 @@ class WC_Gateway_Dintero_HP extends WC_Payment_Gateway
 
 					if ($transaction['amount'] < $amount - 1 ) {
 						$note = sprintf(
-							'Failed to authorize order: Order and transaction amounts do not match. Transaction amount: %s. Order amount: %s. ',
+							'Failed to authorize order: Order and transaction amounts do not match. Transaction amount: %s. Order amount: %s. Handle the order manually in the Dintero Backoffice.',
 							$transaction['amount'],
 							$amount
 						) . $transaction_id;

--- a/includes/class-wc-gateway-dintero-hp.php
+++ b/includes/class-wc-gateway-dintero-hp.php
@@ -1125,8 +1125,8 @@ class WC_Gateway_Dintero_HP extends WC_Payment_Gateway
 
 			$transaction_amount = $transaction['amount'];
 
-			// We experience inexplicable differences of one cent.
-			// To lessen the impact, we will allow difference of one cent,
+			// We experience inexplicable differences of 1 cent (or smallest unit of the currency)
+			// To lessen the impact, we will allow difference of one cent (or smallest unit of the currency),
 			// and will adjust the capture call accordingly
 			if ($order_total_amount === $transaction_amount + 1 ||
 				$order_total_amount === $transaction_amount - 1) {

--- a/includes/class-wc-gateway-dintero-hp.php
+++ b/includes/class-wc-gateway-dintero-hp.php
@@ -1125,7 +1125,7 @@ class WC_Gateway_Dintero_HP extends WC_Payment_Gateway
 
 			$transaction_amount = $transaction['amount'];
 
-			// We experience unexplainable differences of one cent.
+			// We experience inexplicable differences of one cent.
 			// To lessen the impact, we will allow difference of one cent,
 			// and will adjust the capture call accordingly
 			if ($order_total_amount === $transaction_amount + 1 ||

--- a/tests/phpunit/test-class-wc-gateway-dintero-hp.php
+++ b/tests/phpunit/test-class-wc-gateway-dintero-hp.php
@@ -172,7 +172,7 @@ class WC_Gateway_Dintero_HP_Test extends WP_UnitTestCase {
 			'order' => 'DESC',
 			'type' => 'internal',
 		))[0];
-		$this->assertContains('Order and transaction amounts do not match.', $last_note->content);
+		$this->assertContains('Order was authorized with a different amount, so manual handling is required.', $last_note->content);
 	}
 	
 	/**

--- a/tests/phpunit/test-class-wc-gateway-dintero-hp.php
+++ b/tests/phpunit/test-class-wc-gateway-dintero-hp.php
@@ -176,6 +176,45 @@ class WC_Gateway_Dintero_HP_Test extends WP_UnitTestCase {
 	}
 	
 	/**
+	 * @group callback_after_redirect
+	 */
+	public function test_callback_after_redirect_amount_too_high_auto_catpure() {
+		$checkout = new WC_Gateway_Dintero_HP();
+		
+		// Mock query parameters
+		$_GET['transaction_id'] = 'P12345678.55wd4cLGiHcyNrfnCmzeqH';
+		$_GET['session_id'] = 'P12345678.55wd3zjzVCkXXoVFv518q7';
+
+		$order = WC_Helper_Order::create_order(1, null, 15, 1, array());
+
+		$adapter_stub = $this->createMock(Dintero_HP_Adapter::class);
+		$transaction_amount = absint( strval( floatval( $order->get_total() ) * 100 ) ) - 2;
+
+		$transaction = array(
+			'amount' => $transaction_amount,
+			'currency' => 'NOK',
+			'status' => 'CAPTURED',
+			'merchant_reference' => ''.$order->get_id()
+		);
+		$adapter_stub->method('get_transaction')->willReturn($transaction);
+		$checkout::$_adapter = $adapter_stub;
+
+		$checkout->callback(true);
+
+		// check that the order has been updated with the new status
+		$updated_order = wc_get_order( $order->get_id() );
+		$this->assertEquals($updated_order->get_status(), 'on-hold');
+
+		$last_note = wc_get_order_notes(array(
+			'order_id' => $order->get_id(),
+			'limit' => 1,
+			'order' => 'DESC',
+			'type' => 'internal',
+		))[0];
+		$this->assertContains('Order was captured with a different amount. Figure out what the cause is and mark the order as completed when done.', $last_note->content);
+	}
+	
+	/**
 	 * @group capture
 	 */
 	public function test_capture() {


### PR DESCRIPTION
- Allow all transactions where transaction amount is higher than order amount
- Allow order amount to be 1 cent higher than transaction amount
- If order amount is higher than transaction amount + 1, put order on hold and add note to explain the situation.
- Set capture sum to the same as transaction amount if the sums differ by 1 cent

Test cases:

1. Somehow manage to provoke a cent difference, probably by changing the order in wp-admin.
2. Wait for callback to arrive.
3. Watch behaviour.
4. Attempt capture. See that the capture sum is adjusted to be the same.