### PR TITLE
Remove dangling commas in function calls

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, Payment, Checkout, Vipps, Visa, Mastercard, Invoice, Instalme
 Donate link: https://dintero.com
 Requires at least: 4.0
 Tested up to: 5.8
-Requires PHP: 5.6
+Requires PHP: 7.3
 WC requires at least: 3.4.0
 WC tested up to: 5.9.0
 Stable tag: trunk
@@ -43,9 +43,11 @@ When you install Dintero Checkout, you need to head to the settings page to star
 
 == Changelog ==
 
-2021.12.09-php8
+pending
 
-* Fix issues after updating to PHP8
+* Fix edge-case rounding issue with certain discount codes
+* Fix issues with PHP 8
+* Remove dangling commas in function calls to better support PHP 7.2
 
 2021.12.09
 

--- a/dintero-hp.php
+++ b/dintero-hp.php
@@ -2,7 +2,7 @@
 /**
 Plugin Name: Dintero Checkout
 Description: Dintero Checkout - Express Checkout
-Version:     2021.12.09-php8
+Version:     2022.01.03
 Author:      Dintero
 Author URI:  mailto:integration@dintero.com
 Text Domain: dintero-hp
@@ -13,7 +13,7 @@ Domain Path: /languages
 
 defined( 'ABSPATH' ) || exit;
 
-define( 'DINTERO_HP_VERSION', '2021.12.09-php8' );
+define( 'DINTERO_HP_VERSION', '2021.01.03' );
 
 
 

--- a/includes/class-dintero-hp-adapter.php
+++ b/includes/class-dintero-hp-adapter.php
@@ -236,7 +236,7 @@ class Dintero_HP_Adapter
 		$payload = Dintero_HP_Request_Builder::instance()->build($request);
 		$response = _wp_http_get_object()->post(
 			$this->_endpoint(sprintf('/transactions/%s/void', $transaction_id)),
-			$payload,
+			$payload
 		);
 		$response_code = wp_remote_retrieve_response_code($response);
 		$response_body_raw = wp_remote_retrieve_body( $response );

--- a/includes/class-wc-gateway-dintero-hp.php
+++ b/includes/class-wc-gateway-dintero-hp.php
@@ -1095,7 +1095,7 @@ class WC_Gateway_Dintero_HP extends WC_Payment_Gateway
 				$order->add_order_note(__(
 					sprintf(
 						'Dintero transaction has already been captured, and now has status (%s).',
-						$transaction_status,
+						$transaction_status
 					)
 				));
 				$order->save_meta_data();
@@ -1106,7 +1106,7 @@ class WC_Gateway_Dintero_HP extends WC_Payment_Gateway
 				$order->add_order_note(__(
 					sprintf(
 						'Could not capture transaction: Transaction status is wrong (%s). Changing status to on-hold.',
-						$transaction_status,
+						$transaction_status
 					)
 				));
 				$order->set_status( 'on-hold' );


### PR DESCRIPTION
Remove dangling commas in function calls to better support PHP 7.2