### PR TITLE
Update Order Customer Detail template version to 5.6.0

### DIFF
--- a/templates/order/order-details-customer.php
+++ b/templates/order/order-details-customer.php
@@ -12,7 +12,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce/Templates
- * @version 3.4.4
+ * @version 5.6.0
  */
 
 defined( 'ABSPATH' ) || exit;


### PR DESCRIPTION
This is to prevent Woocommerce system report from flagging this template as outdated.